### PR TITLE
Change alias, to avoid clash with yajra Datatables pkg

### DIFF
--- a/src/Bllim/Datatables/DatatablesServiceProvider.php
+++ b/src/Bllim/Datatables/DatatablesServiceProvider.php
@@ -28,7 +28,7 @@ class DatatablesServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app->singleton('datatables', function($app) {
+        $this->app->singleton('bllimdatatables', function($app) {
             return new Datatables;
         });
     }

--- a/src/Bllim/Datatables/Facade/Datatables.php
+++ b/src/Bllim/Datatables/Facade/Datatables.php
@@ -9,6 +9,6 @@ class Datatables extends Facade {
      *
      * @return string
      */
-    protected static function getFacadeAccessor() { return 'datatables'; }
+    protected static function getFacadeAccessor() { return 'bllimdatatables'; }
 
 }


### PR DESCRIPTION
Changed alias from `datatables` to `bllimdatatables`, so it doesn't clash with yajra datatables pkg.