### PR TITLE
Remove and replace Input facade

### DIFF
--- a/src/Bllim/Datatables/Datatables.php
+++ b/src/Bllim/Datatables/Datatables.php
@@ -12,7 +12,6 @@
  */
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Arr;
@@ -64,7 +63,7 @@ class Datatables
     public function __construct()
     {
 
-        $this->setData($this->processData(Input::get()));
+        $this->setData($this->processData(request()->all()));
 
         return $this;
     }


### PR DESCRIPTION
Input facade removed in Laravel 6.

This is causing issues in your tracker package admin when using datatables.